### PR TITLE
Integration test env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.pyc
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,66 @@
+install = <<-EOF
+
+# Unassisted install for java
+echo debconf shared/accepted-oracle-license-v1-1 select true | \
+  sudo debconf-set-selections
+echo debconf shared/accepted-oracle-license-v1-1 seen true | \
+  sudo debconf-set-selections
+
+# Mesos-Key
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF
+
+# Docker-Key
+sudo apt-key adv \
+  --keyserver hkp://ha.pool.sks-keyservers.net:80 \
+  --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+DISTRO=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
+CODENAME=$(lsb_release -cs)
+
+# Java Repo
+sudo add-apt-repository ppa:webupd8team/java
+
+# Mesos Repo
+echo "deb http://repos.mesosphere.com/${DISTRO} ${CODENAME} main" |
+  sudo tee /etc/apt/sources.list.d/mesosphere.list
+
+# Docker Repo
+echo "deb https://apt.dockerproject.org/repo ubuntu-trusty main" |
+  sudo tee /etc/apt/sources.list.d/docker.list
+
+# Update
+sudo apt-get -y update
+
+# Install packages
+sudo apt-get install apt-transport-https ca-certificates
+sudo apt-get -y install oracle-java8-installer zookeeper docker-engine mesos marathon collectd python-pip
+sudo pip install python-dateutil docker-py
+
+# Master Config
+echo '192.168.33.33' > /etc/mesos-master/advertise_ip
+touch /etc/mesos-master/no-hostname_lookup
+
+# Slave Config
+echo '192.168.33.33' > /etc/mesos-slave/advertise_ip
+echo 'docker' > /etc/mesos-slave/containerizers
+touch /etc/mesos-slave/no-hostname_lookup
+
+services=(zookeeper docker mesos-master mesos-slave marathon collectd)
+
+# Stop
+for svc in ${services[@]}; do
+  sudo service $svc stop
+done
+
+# Start
+for svc in ${services[@]}; do
+  sudo service $svc start
+  sleep 1
+done
+
+EOF
+
+Vagrant.configure('2') do |config|
+  config.vm.box = 'ubuntu/trusty64'
+  config.vm.network(:private_network, ip: '192.168.33.33')
+  config.vm.provision(:shell, inline: install)
+end

--- a/config/test.conf
+++ b/config/test.conf
@@ -1,0 +1,28 @@
+
+TypesDB "/usr/share/collectd/types.db" "/usr/share/collectd/dockerplugin.db"
+
+LoadPlugin csv
+LoadPlugin python
+
+LoadPlugin logfile
+LoadPlugin syslog
+
+<Plugin logfile>
+       LogLevel "info"
+       File STDOUT
+       Timestamp true
+       PrintSeverity true
+</Plugin>
+
+<Plugin csv>
+       DataDir "/var/lib/collectd/csv"
+       StoreRates false
+</Plugin>
+
+<Plugin python>
+       ModulePath "/usr/share/collectd/python"
+       LogTraces true
+       Import "dockerplugin"
+       <Module dockerplugin>
+       </Module>
+</Plugin>

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -24,8 +24,11 @@ EOF)"
 }
 
 main(){
+  # Ensure test app is running
   deploy_test_app
+  # Deploy resources and restart collectd
   script="$(cat <<EOF
+    [ -d /var/lib/collectd/csv ] && sudo rm -rf /var/lib/collectd/csv/*
     [ ! -d /usr/share/collectd/python ] && sudo mkdir /usr/share/collectd/python
     sudo cp -f /vagrant/config/* /etc/collectd/collectd.conf.d/
     sudo cp -f /vagrant/dockerplugin.py /usr/share/collectd/python/

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+deploy_test_app(){
+  payload="$(cat <<'EOF'
+{
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "network": "HOST",
+      "image": "alpine"
+    }
+  },
+  "cmd": "while true; do sleep 1; done"
+}
+EOF)"
+
+  curl                                  \
+    -X PUT                              \
+    -H 'Content-Type: application/json' \
+    -d "$payload"                       \
+    http://192.168.33.33:8080/v2/apps/test
+}
+
+main(){
+  deploy_test_app
+  script="$(cat <<EOF
+    [ ! -d /usr/share/collectd/python ] && sudo mkdir /usr/share/collectd/python
+    sudo cp -f /vagrant/config/* /etc/collectd/collectd.conf.d/
+    sudo cp -f /vagrant/dockerplugin.py /usr/share/collectd/python/
+    sudo cp -f /vagrant/dockerplugin.db /usr/share/collectd/
+    # Need this, otherwise we get a parse error
+    echo "" | sudo tee -a /etc/collectd/collectd.conf.d/test.conf
+    sudo service collectd restart
+EOF)"
+  vagrant ssh -c "$script"
+}
+
+main


### PR DESCRIPTION
I started down the path of creating a test environment for developing on this plugin. While I didn't end up having to add a feature, this should be helpful for anyone wanting to extend this plugin without breaking it. 

* Vagrant installs Java, Zookeeper, Mesos, Marathon, and CollectD
* Deploy script sets up the types.db file, the plugin, and a test configuration that leverages the CSV modules for verifying the dispatch output. The deploy script also deploys a simple marathon application. An integration test can check each of the files generated from the Marathon deployment and verify that the output makes sense. 